### PR TITLE
Rename joint_clustering to `joint`, wire through training, and tidy section loop style

### DIFF
--- a/SpaHDmap/train.py
+++ b/SpaHDmap/train.py
@@ -1361,6 +1361,7 @@ class Mapper:
                 use_score: str = 'SpaHDmap',
                 resolution: float = 0.8,
                 n_neighbors: int = 50,
+                joint: bool = True,
                 format: str = 'png',
                 show: bool = True):
         """
@@ -1376,6 +1377,8 @@ class Mapper:
             Resolution parameter for Louvain clustering.
         n_neighbors
             Number of neighbors for graph construction.
+        joint
+            Whether to cluster spots/pixels jointly across sections.
         format
             Output format for visualization ('jpg', 'png', 'pdf').
         show
@@ -1395,6 +1398,7 @@ class Mapper:
             use_score=use_score,
             resolution=resolution,
             n_neighbors=n_neighbors,
+            joint=joint,
             verbose=self.verbose
         )
 


### PR DESCRIPTION
### Motivation

- Consolidate the joint-clustering flag name to `joint` and expose it to the top-level `Mapper.cluster` API so callers can request joint spot/pixel clustering from training code paths. 
- Keep backward-compatible per-section clustering behavior when joint clustering is not requested. 
- Maintain the original code style of iterating with `for section in sections` and fix inconsistent variable names introduced earlier.

### Description

- Renamed the flag `joint_clustering` to `joint` in `SpaHDmap/utils/clustering.py` and updated the docstring for `cluster_score` to describe `joint`.
- Added the `joint: bool = True` parameter to `Mapper.cluster` in `SpaHDmap/train.py` and forwarded it to `cluster_score` via `joint=joint`.
- Replaced inconsistent loop variable names (e.g. `current_section`/`current`) with the established `for section in sections` style across `cluster_score` to match project conventions.
- Implemented wiring for joint clustering: when `joint` is true and multiple sections are provided, spot embeddings are concatenated, Louvain is run jointly, and spot labels are split back per section; joint pixel-level KMeans is handled by the added `_extend_clustering_to_pixels_joint` helper which concatenates valid pixel feature matrices, runs KMeans initialized from spot cluster centers, and slices results back into per-section label maps.
- Preserved per-section behavior (original flow) when `joint` is false or only a single section is provided.

### Testing

- Ran `python -m pytest`, which completed successfully but reported that no tests were collected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c523217648324adb190530dcb5eee)